### PR TITLE
statement: initial support for common table expressions

### DIFF
--- a/spec/suite/statement/delete.spec.js
+++ b/spec/suite/statement/delete.spec.js
@@ -144,6 +144,38 @@ describe("Delete", function() {
 
   });
 
+  describe(".with()", function() {
+    it('accepts a single query', function() {
+      this.delete
+        .with({'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}) })
+        .from('table')
+      expect(this.delete.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\'))DELETE FROM "table"');
+    });
+    it('accepts multiple query single query', function() {
+      this.delete
+        .with({
+          'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}),
+          'bar': this.dialect.statement('insert').into('table_b').values({a: 'b'})
+        })
+        .from('table')
+        .where({ '=': [1, 1]})
+      expect(this.delete.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\')), bar AS (INSERT INTO "table_b" ("a") VALUES (\'b\'))DELETE FROM "table" WHERE 1 = 1');
+    });
+
+    it('throws with duplicate names', function() {
+      expect(function(){
+        this.delete
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'}),
+          })
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'}),
+          })
+          .from('table')
+      }.bind(this)).toThrow(new Error("Common table expression foo specified more than once"));
+    });
+  });
+
   describe(".toString()" , function() {
 
     it("casts object to string query", function() {

--- a/spec/suite/statement/insert.spec.js
+++ b/spec/suite/statement/insert.spec.js
@@ -67,6 +67,49 @@ describe("Insert", function() {
 
   });
 
+  describe(".with()", function() {
+    it('accepts a single query', function() {
+      this.insert
+        .with({'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}) })
+        .into('table')
+        .values({
+          field1: 'value1',
+          field2: 'value2'
+        })
+      expect(this.insert.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\'))INSERT INTO "table" ("field1", "field2") VALUES (\'value1\', \'value2\')');
+    })
+    it('accepts multiple query single query', function() {
+      this.insert
+        .with({
+          'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}),
+          'bar': this.dialect.statement('insert').into('table_b').values({a: 'b'})
+        })
+        .into('table')
+        .values({
+          field1: 'value1',
+          field2: 'value2'
+        })
+      expect(this.insert.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\')), bar AS (INSERT INTO "table_b" ("a") VALUES (\'b\'))INSERT INTO "table" ("field1", "field2") VALUES (\'value1\', \'value2\')');
+    })
+
+    it('throws with duplicate names', function() {
+      expect(function(){
+        this.insert
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .into('table')
+          .values({
+            field1: 'value1',
+            field2: 'value2'
+          });
+      }.bind(this)).toThrow(new Error("Common table expression foo specified more than once"));
+    });
+  });
+
   describe(".toString()" , function() {
 
     it("casts object to string query", function() {

--- a/spec/suite/statement/select.spec.js
+++ b/spec/suite/statement/select.spec.js
@@ -411,6 +411,36 @@ describe("Select", function() {
 
   });
 
+  describe(".with()", function() {
+    it('accepts a single query', function() {
+      this.select
+        .with({'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}) })
+        .from('table')
+      expect(this.select.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\'))SELECT * FROM "table"');
+    })
+    it('accepts multiple query single query', function() {
+      this.select
+        .with({
+          'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}),
+          'bar': this.dialect.statement('insert').into('table_b').values({a: 'b'})
+        })
+        .from('table')
+      expect(this.select.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\')), bar AS (INSERT INTO "table_b" ("a") VALUES (\'b\'))SELECT * FROM "table"');
+    })
+
+    it('throws with duplicate names', function() {
+      expect(function(){
+        this.select
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .from('table')
+      }.bind(this)).toThrow(new Error("Common table expression foo specified more than once"));
+    });
+  });
   describe(".toString()" , function() {
 
     it("casts object to string query", function() {

--- a/spec/suite/statement/update.spec.js
+++ b/spec/suite/statement/update.spec.js
@@ -212,6 +212,41 @@ describe("Update", function() {
 
   });
 
+  describe(".with()", function() {
+    it('accepts a single query', function() {
+      this.update
+        .with({'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}) })
+        .table('table')
+        .values({ field: 'value' });
+      expect(this.update.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\'))UPDATE "table" SET "field" = \'value\'');
+    });
+    it('accepts multiple query single query', function() {
+      this.update
+        .with({
+          'foo': this.dialect.statement('insert').into('table_a').values({a: 'b'}),
+          'bar': this.dialect.statement('insert').into('table_b').values({a: 'b'})
+        })
+        .table('table')
+        .values({ field: 'value' })
+        .where({ '=': [1, 1]});
+      expect(this.update.toString()).toBe('WITH foo AS (INSERT INTO "table_a" ("a") VALUES (\'b\')), bar AS (INSERT INTO "table_b" ("a") VALUES (\'b\'))UPDATE "table" SET "field" = \'value\' WHERE 1 = 1');
+    });
+
+    it('throws with duplicate names', function() {
+      expect(function(){
+        this.update
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .with({
+            'foo': this.dialect.statement('insert').into('foo').values({a: 'b'})
+          })
+          .table('table')
+          .values({ field: 'value' });
+      }.bind(this)).toThrow(new Error("Common table expression foo specified more than once"));
+    });
+  });
+
   describe(".toString()" , function() {
 
     it("casts object to string query", function() {

--- a/src/statement/delete.js
+++ b/src/statement/delete.js
@@ -11,7 +11,6 @@ const DELETE = 'DELETE';
  */
 class Delete extends Statement {
 
-
   /**
    * Constructor.
    *
@@ -37,6 +36,7 @@ class Delete extends Statement {
       flags    : new Map(),
       from     : '',
       where    : [],
+      with     : new Map(),
       order    : new Map(),
       limit    : '',
       returning: []
@@ -65,16 +65,18 @@ class Delete extends Statement {
     }
 
     const dialect = this.dialect();
-    return (DELETE +
-      this._buildFlags(this._parts.flags) +
-      this._buildClause(FROM, dialect.names(this._parts.from)) +
+    return [
+      this._buildCTE(),
+      DELETE,
+      this._buildFlags(this._parts.flags),
+      this._buildClause(FROM, dialect.names(this._parts.from)),
       this._buildClause(WHERE,  dialect.conditions(this._parts.where, {
         schemas: { '': this._schema }
-      })) +
-      this._buildOrder() +
-      this._buildClause(LIMIT, this._parts.limit) +
+      })),
+      this._buildOrder(),
+      this._buildClause(LIMIT, this._parts.limit),
       this._buildClause(RETURNING, dialect.names(this._parts.returning))
-     );
+    ].join('');
   }
 
 }

--- a/src/statement/insert.js
+++ b/src/statement/insert.js
@@ -30,6 +30,7 @@ class Insert extends Statement {
       flags     : new Map(),
       into      : '',
       values    : [],
+      with      : new Map(),
       returning : []
     }
   }
@@ -71,6 +72,7 @@ class Insert extends Statement {
     const dialect = this.dialect();
 
     return [
+      this._buildCTE(),
       'INSERT',
       this._buildFlags(this._parts.flags),
       this._buildClause('INTO', dialect.name(this._parts.into, true)),

--- a/src/statement/select.js
+++ b/src/statement/select.js
@@ -30,6 +30,7 @@ class Select extends Statement {
       from     : [],
       joins    : [],
       where    : [],
+      with     : new Map(),
       group    : new Map(),
       having   : [],
       order    : new Map(),
@@ -191,7 +192,8 @@ class Select extends Statement {
     const dialect = this.dialect()
     const fields = dialect.names(this._parts.fields);
     const opts = { schemas: schemas, aliases: aliases }
-    var sql = 'SELECT' +
+    var sql = this._buildCTE() +
+      'SELECT' +
       this._buildFlags(this._parts.flags) +
       this._buildChunk(fields ? fields : '*') +
       this._buildClause('FROM', dialect.names(this._parts.from)) +

--- a/src/statement/update.js
+++ b/src/statement/update.js
@@ -31,6 +31,7 @@ class Update extends Statement {
       table    : '',
       values   : {},
       where    : [],
+      with     : new Map(),
       order    : new Map(),
       limit    : '',
       forUpdate: false,
@@ -74,16 +75,19 @@ class Update extends Statement {
       throw new Error("Invalid `UPDATE` statement, missing `VALUES` clause.");
     }
 
-    return 'UPDATE' +
-      this._buildFlags(this._parts.flags) +
-      this._buildChunk(this.dialect().names(this._parts.table)) +
-      this._buildSet() +
+    return [
+      this._buildCTE(),
+      'UPDATE',
+      this._buildFlags(this._parts.flags),
+      this._buildChunk(this.dialect().names(this._parts.table)),
+      this._buildSet(),
       this._buildClause('WHERE',  this.dialect().conditions(this._parts.where, { schemas: {
         '': this._schema
-      }})) +
-      this._buildOrder() +
-      this._buildClause('LIMIT', this._parts.limit) +
-      this._buildClause('RETURNING', this.dialect().names(this._parts.returning));
+      }})),
+      this._buildOrder(),
+      this._buildClause('LIMIT', this._parts.limit),
+      this._buildClause('RETURNING', this.dialect().names(this._parts.returning))
+    ].join('');
   }
 
   /**


### PR DESCRIPTION
All supported dialects have common table expressions at this point.
This includes a first pass at including support for WITH statement on
all DML statements

TODO:

- [x]  add tests

Semver: minor